### PR TITLE
UNRW-536: Add a headline featured field for inclusion in the timeline

### DIFF
--- a/src/RWAPIIndexer/Resources/Report.php
+++ b/src/RWAPIIndexer/Resources/Report.php
@@ -33,7 +33,7 @@ class Report extends \RWAPIIndexer\Resource {
       'field_headline_image' => array(
         'headline_image' => 'image_reference',
       ),
-      'field_featured' => array(
+      'field_headline_featured' => array(
         'headline_featured' => 'value',
       ),
       'field_image' => array(


### PR DESCRIPTION
This adds a "featured" subfield to the "headline" field for inclusion in the headline timeline on crisis pages.

The field is either set to "true" or not present so it's easy to filter using `filter[field]=headline.featured` for example.

Note 1: The featured field on the drupal side will be deployed on Tuesday 20 Jan 5am GMT.
Note 2: The api itself needs to be updated to allow filtering on this field.

cc @grayside 
