### PR TITLE
Encode file/image urls

### DIFF
--- a/src/RWAPIIndexer/Processor.php
+++ b/src/RWAPIIndexer/Processor.php
@@ -399,6 +399,18 @@ class Processor {
     if (!empty($style)) {
       $base .= 'styles/' . $style . '/public/';
     }
-    return str_replace('public://', $base, $path);
+    return $base . $this->encodePath(str_replace('public://', '', $path));
+  }
+
+  /**
+   * Encode url path.
+   *
+   * @param string $path
+   *   Path to encode.
+   * @return string
+   *   Encoded path.
+   */
+  public function encodePath($path) {
+    return str_replace('%2F', '/', rawurlencode($path));
   }
 }


### PR DESCRIPTION
Fix long lasting bug where file and image urls are not encoded. 

This is kind of a breaking change but it's for the greater good so taking the decision to apply the fix.