### PR TITLE
[wVJgoIMu] add order value for faq

### DIFF
--- a/src/RWAPIIndexer/Resources/Faq.php
+++ b/src/RWAPIIndexer/Resources/Faq.php
@@ -17,6 +17,9 @@ class Faq extends \RWAPIIndexer\Resource {
       'field_status' => array(
         'status' => 'value',
       ),
+      'field_order' => array(
+        'list_order' => 'value',
+      ),
       'body' => array(
         'body' => 'value',
       ),
@@ -52,6 +55,7 @@ class Faq extends \RWAPIIndexer\Resource {
             ->addString('url', FALSE)
             ->addString('url_alias', FALSE)
             ->addString('status', FALSE)
+            ->addInteger('list_order')
             ->addString('title', TRUE, TRUE)
             // Body.
             ->addString('body')


### PR DESCRIPTION
Indexes new 'order' field for https://trello.com/c/wVJgoIMu/894-allow-ordering-the-faq-nodes

I tried called the alias "order" for some time until I realized using a reserved mysql keyword was breaking the query.