### PR TITLE
[OPS-8064] Allow for a specific number of shards per index (default i 1) and allow a number of replicas to be set (default is also 1).

### DIFF
--- a/src/RWAPIIndexer/Elasticsearch.php
+++ b/src/RWAPIIndexer/Elasticsearch.php
@@ -228,7 +228,7 @@ class Elasticsearch {
 
     $settings = $this->defaultSettings;
     $settings['number_of_shards'] = $shards;
-    $settings['number_of_replicas'] = $eplicas;
+    $settings['number_of_replicas'] = $replicas;
 
     $this->request('PUT', $path, [
       'settings' => $settings,

--- a/src/RWAPIIndexer/Elasticsearch.php
+++ b/src/RWAPIIndexer/Elasticsearch.php
@@ -28,13 +28,6 @@ class Elasticsearch {
   protected $tag = '';
 
   /**
-   * Maintain replicas.
-   *
-   * @var int
-   */
-  protected $replicas = 1;
-
-  /**
    * Default index settings.
    *
    * @var array
@@ -145,14 +138,11 @@ class Elasticsearch {
    *   Base index name.
    * @param string $tag
    *   Index tag.
-   * @param replicas $replicas
-   *   The number of replicas for each index.
    */
-  public function __construct($server, $base, $tag = '', $replicas = 1) {
+  public function __construct($server, $base, $tag = '') {
     $this->server = $server;
     $this->base = $base . '_';
     $this->tag = !empty($tag) ? '_' . $tag : '';
-    $this->replicas = $replicas;
   }
 
   /**
@@ -190,10 +180,12 @@ class Elasticsearch {
    *   Index mapping.
    * @param int $shards
    *   The number of shards for this index.
+   * @param int $replicas
+   *   The number of replicas for this index.
    */
-  public function create($index, array $mapping, int $shards = 1) {
+  public function create($index, array $mapping, int $shards, int $replicas) {
     if (!$this->indexExists($index)) {
-      $this->createIndex($index, $mapping, $shards);
+      $this->createIndex($index, $mapping, $shards, $replicas);
     }
   }
 
@@ -228,13 +220,15 @@ class Elasticsearch {
    *   Index mapping.
    * @param int $shards
    *   The number of shards for this index.
+   * @param int $replicas
+   *   The number of replicas for this index.
    */
-  public function createIndex($index, array $mapping, int $shards = 1) {
+  public function createIndex($index, array $mapping, int $shards, int $replicas) {
     $path = $this->getIndexPath($index);
 
     $settings = $this->defaultSettings;
     $settings['number_of_shards'] = $shards;
-    $settings['number_of_replicas'] = $this->replicas;
+    $settings['number_of_replicas'] = $eplicas;
 
     $this->request('PUT', $path, [
       'settings' => $settings,

--- a/src/RWAPIIndexer/Manager.php
+++ b/src/RWAPIIndexer/Manager.php
@@ -74,7 +74,7 @@ class Manager {
       $this->options->get('elasticsearch'),
       $this->options->get('base-index-name'),
       $this->options->get('tag'),
-      $this->options->get('no-replica'),
+      $this->options->get('replicas'),
     );
 
     // Create a new field processor object to prepare items before indexing.

--- a/src/RWAPIIndexer/Manager.php
+++ b/src/RWAPIIndexer/Manager.php
@@ -74,7 +74,6 @@ class Manager {
       $this->options->get('elasticsearch'),
       $this->options->get('base-index-name'),
       $this->options->get('tag'),
-      $this->options->get('replicas'),
     );
 
     // Create a new field processor object to prepare items before indexing.

--- a/src/RWAPIIndexer/Options.php
+++ b/src/RWAPIIndexer/Options.php
@@ -32,7 +32,8 @@ class Options {
     'alias' => FALSE,
     'alias-only' => FALSE,
     'simulate' => FALSE,
-    'no-replica' => FALSE,
+    'replicas' => 1,
+    'shards' => 1,
     'log' => '',
   ];
 
@@ -170,9 +171,14 @@ class Options {
           $options['simulate'] = TRUE;
           break;
 
-        case '--no-replica':
-        case '-n':
-          $options['no-replica'] = TRUE;
+        case '--replicas':
+        case '-R':
+          $options['replicas'] = (int) array_shift($argv);
+          break;
+
+        case '--shards':
+        case '-S':
+          $options['shards'] = (int) array_shift($argv);
           break;
 
         case '--help':
@@ -338,8 +344,14 @@ class Options {
         'filter' => FILTER_VALIDATE_BOOLEAN,
         'flags' => FILTER_NULL_ON_FAILURE,
       ],
-      'no-replica' => [
-        'filter' => FILTER_VALIDATE_BOOLEAN,
+      'replicas' => [
+        'filter' => FILTER_VALIDATE_INT,
+        'options' => ['min_range' => 0],
+        'flags' => FILTER_NULL_ON_FAILURE,
+      ],
+      'shards' => [
+        'filter' => FILTER_VALIDATE_INT,
+        'options' => ['min_range' => 1, 'max_range' => 8],
         'flags' => FILTER_NULL_ON_FAILURE,
       ],
     ]);
@@ -382,7 +394,8 @@ class Options {
           "     -a, --alias Set up the alias for the index after the indexing, ignored if id is provided \n" .
           "     -A, --alias-only Set up the alias for the index without indexing, ignored if id is provided \n" .
           "     -s, --simulate Return the number of indexable entities based on the provided limit and offset \n" .
-          "     -n, --no-replica Create an index without a replica \n\n";
+          "     -R, --replicas Create indices with this number of replicas, defaults to 1. Allowed: 0 or more \n\n";
+          "     -S, --shards Create indices with this number of shards, defaults to 1. Allowed: 1-8) \n\n";
     exit();
   }
 

--- a/src/RWAPIIndexer/Options.php
+++ b/src/RWAPIIndexer/Options.php
@@ -394,7 +394,7 @@ class Options {
           "     -a, --alias Set up the alias for the index after the indexing, ignored if id is provided \n" .
           "     -A, --alias-only Set up the alias for the index without indexing, ignored if id is provided \n" .
           "     -s, --simulate Return the number of indexable entities based on the provided limit and offset \n" .
-          "     -R, --replicas Create indices with this number of replicas, defaults to 1. Allowed: 0 or more \n";
+          "     -R, --replicas Create indices with this number of replicas, defaults to 1. Allowed: 0 or more \n" .
           "     -S, --shards Create indices with this number of shards, defaults to 1. Allowed: 1-8) \n\n";
     exit();
   }

--- a/src/RWAPIIndexer/Options.php
+++ b/src/RWAPIIndexer/Options.php
@@ -394,7 +394,7 @@ class Options {
           "     -a, --alias Set up the alias for the index after the indexing, ignored if id is provided \n" .
           "     -A, --alias-only Set up the alias for the index without indexing, ignored if id is provided \n" .
           "     -s, --simulate Return the number of indexable entities based on the provided limit and offset \n" .
-          "     -R, --replicas Create indices with this number of replicas, defaults to 1. Allowed: 0 or more \n\n";
+          "     -R, --replicas Create indices with this number of replicas, defaults to 1. Allowed: 0 or more \n";
           "     -S, --shards Create indices with this number of shards, defaults to 1. Allowed: 1-8) \n\n";
     exit();
   }

--- a/src/RWAPIIndexer/Resource.php
+++ b/src/RWAPIIndexer/Resource.php
@@ -376,8 +376,11 @@ abstract class Resource {
     // Set the number of shards for the index to be created.
     $shards = $this->options->get('shards') ?? 1;
 
+    // Set the number of replicas for the index to be created.
+    $replicas = $this->options->get('replicas') ?? 1;
+
     // Create the index and set up the mapping for the entity bundle.
-    $this->elasticsearch->create($this->index, $this->getMapping(), $shards);
+    $this->elasticsearch->create($this->index, $this->getMapping(), $shards, $replicas);
 
     // Counter of indexed items.
     $count = 0;

--- a/src/RWAPIIndexer/Resource.php
+++ b/src/RWAPIIndexer/Resource.php
@@ -134,7 +134,7 @@ abstract class Resource {
     $conditions = [];
     if (!empty($filters)) {
       foreach (explode('+', $filters) as $filter) {
-        list($field, $value) = explode(':', $filter, 2);
+        [$field, $value] = explode(':', $filter, 2);
         // This is to check the existence of a field.
         if ($value === '*') {
           $values = '*';

--- a/src/RWAPIIndexer/Resource.php
+++ b/src/RWAPIIndexer/Resource.php
@@ -373,8 +373,11 @@ abstract class Resource {
 
     $this->log("Indexing {$this->bundle} entities.\n");
 
+    // Set the number of shards for the index to be created.
+    $shards = $this->options->get('shards') ?? 1;
+
     // Create the index and set up the mapping for the entity bundle.
-    $this->elasticsearch->create($this->index, $this->getMapping());
+    $this->elasticsearch->create($this->index, $this->getMapping(), $shards);
 
     // Counter of indexed items.
     $count = 0;


### PR DESCRIPTION
In theory this does not break the current logic for replicas (although we do need to tweak the non-prod setting) and it should also allow us to split the large indices into smaller shards for more efficient searching and recovery.