### PR TITLE
[RW-594] Add dates to countries, disasters and sources

### DIFF
--- a/src/RWAPIIndexer/Resources/Country.php
+++ b/src/RWAPIIndexer/Resources/Country.php
@@ -18,6 +18,8 @@ class Country extends Resource {
       'name' => 'name',
       'description' => 'description__value',
       'status' => 'moderation_status',
+      'date_created' => 'created',
+      'date_changed' => 'changed',
     ],
     'field_joins' => [
       'field_shortname' => [
@@ -46,6 +48,8 @@ class Country extends Resource {
       'featured' => ['bool'],
       'latitude' => ['float'],
       'longitude' => ['float'],
+      'date_created' => ['time'],
+      'date_changed' => ['time'],
     ],
   ];
 
@@ -95,6 +99,8 @@ class Country extends Resource {
       // Description -- legacy.
       ->addString('description')
       ->addString('description-html', NULL)
+      // Dates.
+      ->addDates('date', ['created', 'changed'])
       // Profile.
       ->addProfile($this->profileSections);
 
@@ -105,6 +111,16 @@ class Country extends Resource {
    * {@inheritdoc}
    */
   public function processItem(&$item) {
+    // Handle dates.
+    if (isset($item['date_created'])) {
+      $item['date']['created'] = $item['date_created'];
+      unset($item['date_created']);
+    }
+    if (isset($item['date_changed'])) {
+      $item['date']['changed'] = $item['date_changed'];
+      unset($item['date_changed']);
+    }
+
     // Legacy "current" status.
     if (!empty($item['status']) && ($item['status'] === 'current' || $item['status'] === 'ongoing')) {
       $item['current'] = TRUE;

--- a/src/RWAPIIndexer/Resources/Source.php
+++ b/src/RWAPIIndexer/Resources/Source.php
@@ -18,6 +18,8 @@ class Source extends Resource {
       'name' => 'name',
       'description' => 'description__value',
       'status' => 'moderation_status',
+      'date_created' => 'created',
+      'date_changed' => 'changed',
     ],
     'field_joins' => [
       'field_shortname' => [
@@ -60,6 +62,8 @@ class Source extends Resource {
       'content_type' => ['multi_int'],
       'type' => ['single'],
       'fts_id' => ['int'],
+      'date_created' => ['time'],
+      'date_changed' => ['time'],
     ],
     'references' => [
       'type' => [
@@ -106,6 +110,8 @@ class Source extends Resource {
       ->addInteger('fts_id')
       // Logo.
       ->addImage('logo')
+      // Dates.
+      ->addDates('date', ['created', 'changed'])
       // Disclaimer.
       ->addString('disclaimer', FALSE);
 
@@ -116,6 +122,16 @@ class Source extends Resource {
    * {@inheritdoc}
    */
   public function processItem(&$item) {
+    // Handle dates.
+    if (isset($item['date_created'])) {
+      $item['date']['created'] = $item['date_created'];
+      unset($item['date_created']);
+    }
+    if (isset($item['date_changed'])) {
+      $item['date']['changed'] = $item['date_changed'];
+      unset($item['date_changed']);
+    }
+
     // Content type.
     if (!empty($item['content_type'])) {
       foreach ($item['content_type'] as $key => $value) {


### PR DESCRIPTION
Refs: RW-594

Sister PR of https://github.com/UN-OCHA/rwint-api/pull/96 and https://github.com/UN-OCHA/rwint9-site/pull/406

This adds indexing of the `created` and `changed` dates for countries, disasters and sources.

For disasters, there is also the "event" date (previous created date).