### PR TITLE
[RW-598] Add indexing of topics

### DIFF
--- a/src/RWAPIIndexer/Bundles.php
+++ b/src/RWAPIIndexer/Bundles.php
@@ -40,6 +40,11 @@ class Bundles {
       'type' => 'node',
       'index' => 'book',
     ],
+    'topic' => [
+      'class' => '\RWAPIIndexer\Resources\Topic',
+      'type' => 'node',
+      'index' => 'topics',
+    ],
     'country' => [
       'class' => '\RWAPIIndexer\Resources\Country',
       'type' => 'taxonomy_term',

--- a/src/RWAPIIndexer/Mapping.php
+++ b/src/RWAPIIndexer/Mapping.php
@@ -200,6 +200,28 @@ class Mapping {
   }
 
   /**
+   * Add a river search field definition to the mapping.
+   *
+   * @param string $field
+   *   Field Name.
+   * @param string $alias
+   *   Field index alias.
+   *
+   * @return \RWAPIIndexer\Bundles
+   *   This Mapping instance.
+   */
+  public function addRiverSearch($field, $alias = '') {
+    $properties = [
+      'id' => ['type' => 'keyword'],
+      'url' => ['type' => 'keyword'],
+      'title' => ['type' => 'text', 'norms' => FALSE],
+      'override' => ['type' => 'integer'],
+    ];
+    $this->addFieldMapping($field, ['properties' => $properties], $alias);
+    return $this;
+  }
+
+  /**
    * Add a file field definition to the mapping.
    *
    * @param string $field

--- a/src/RWAPIIndexer/Processor.php
+++ b/src/RWAPIIndexer/Processor.php
@@ -674,7 +674,7 @@ class Processor {
 
         foreach ($array as $key => $value) {
           if (empty($value)) {
-            unset($key);
+            unset($array[$key]);
           }
         }
 
@@ -780,7 +780,7 @@ class Processor {
 
         foreach ($array as $key => $value) {
           if (empty($value)) {
-            unset($key);
+            unset($array[$key]);
           }
         }
 
@@ -988,6 +988,49 @@ class Processor {
         $this->processConversion(['html'], $item['profile'], 'overview');
       }
     }
+  }
+
+  /**
+   * Process a river search field.
+   *
+   * @param string $field
+   *   Image information to convert to image field.
+   * @param bool $single
+   *   Indicates that the field should could contain a single value.
+   *
+   * @return bool
+   *   Processing success.
+   */
+  public function processRiverSearch(&$field, $single = FALSE) {
+    if (isset($field) && !empty($field)) {
+      $items = [];
+      foreach (explode('%%%', $field) as $item) {
+        [
+          $url,
+          $title,
+          $override,
+        ] = explode('###', $item);
+
+        $array = [
+          'url' => $url,
+          'title' => $title,
+          'override' => !empty($override) ? intval($override, 10) : NULL,
+        ];
+
+        foreach ($array as $key => $value) {
+          if (empty($value)) {
+            unset($array[$key]);
+          }
+        }
+
+        $items[] = $array;
+      }
+      if (!empty($items)) {
+        $field = $single ? $items[0] : $items;
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/src/RWAPIIndexer/Processor.php
+++ b/src/RWAPIIndexer/Processor.php
@@ -634,6 +634,7 @@ class Processor {
       $items = [];
       foreach (explode('%%%', $field) as $item) {
         [
+          $delta,
           $id,
           $width,
           $height,
@@ -678,10 +679,11 @@ class Processor {
           }
         }
 
-        $items[] = $array;
+        $items[$delta] = $array;
       }
+      ksort($items);
       if (!empty($items)) {
-        $field = $single ? $items[0] : $items;
+        $field = $single ? reset($items) : array_values($items);
         return TRUE;
       }
     }
@@ -704,6 +706,7 @@ class Processor {
       $items = [];
       foreach (explode('%%%', $field) as $item) {
         [
+          $delta,
           $id,
           $uuid,
           $filename,
@@ -784,10 +787,11 @@ class Processor {
           }
         }
 
-        $items[] = $array;
+        $items[$delta] = $array;
       }
+      ksort($items);
       if (!empty($items)) {
-        $field = $single ? $items[0] : $items;
+        $field = $single ? reset($items) : array_values($items);
         return TRUE;
       }
     }
@@ -1006,6 +1010,7 @@ class Processor {
       $items = [];
       foreach (explode('%%%', $field) as $item) {
         [
+          $delta,
           $url,
           $title,
           $override,
@@ -1023,10 +1028,11 @@ class Processor {
           }
         }
 
-        $items[] = $array;
+        $items[$delta] = $array;
       }
+      ksort($array);
       if (!empty($items)) {
-        $field = $single ? $items[0] : $items;
+        $field = $single ? reset($items) : array_values($items);
         return TRUE;
       }
     }

--- a/src/RWAPIIndexer/Query.php
+++ b/src/RWAPIIndexer/Query.php
@@ -446,6 +446,15 @@ class Query {
               $query->addExpression($expression, $alias);
               break;
 
+            case 'river_search':
+              $expression = "GROUP_CONCAT(DISTINCT IF({$field_table}.{$field_name}_url IS NOT NULL, CONCAT_WS('###',
+                  {$field_table}.{$field_name}_url,
+                  IFNULL({$field_table}.{$field_name}_title, ''),
+                  IFNULL({$field_table}.{$field_name}_override, '')
+                ), NULL) SEPARATOR '%%%')";
+              $query->addExpression($expression, $alias);
+              break;
+
             default:
               $query->addField($field_table, $field_name . '_' . $value, $alias);
           }

--- a/src/RWAPIIndexer/Query.php
+++ b/src/RWAPIIndexer/Query.php
@@ -411,6 +411,7 @@ class Query {
               $query->leftJoin($file_managed_table, $file_managed_alias, "{$file_managed_alias}.fid = {$media_image_alias}.{$media_image_field}_target_id");
 
               $expression = "GROUP_CONCAT(DISTINCT IF({$field_table}.{$field_name}_target_id IS NOT NULL, CONCAT_WS('###',
+                  {$field_table}.delta,
                   {$field_table}.{$field_name}_target_id,
                   IFNULL({$media_image_alias}.{$media_image_field}_width, ''),
                   IFNULL({$media_image_alias}.{$media_image_field}_height, ''),
@@ -431,6 +432,7 @@ class Query {
               $query->leftJoin($file_managed_table, $file_managed_alias, "{$file_managed_alias}.uuid = {$field_table}.{$field_name}_file_uuid");
 
               $expression = "GROUP_CONCAT(DISTINCT IF({$field_table}.{$field_name}_file_uuid IS NOT NULL, CONCAT_WS('###',
+                  {$field_table}.delta,
                   IFNULL({$field_table}.{$field_name}_revision_id, ''),
                   IFNULL({$field_table}.{$field_name}_uuid, ''),
                   IFNULL({$field_table}.{$field_name}_file_name, ''),
@@ -448,6 +450,7 @@ class Query {
 
             case 'river_search':
               $expression = "GROUP_CONCAT(DISTINCT IF({$field_table}.{$field_name}_url IS NOT NULL, CONCAT_WS('###',
+                  {$field_table}.delta,
                   {$field_table}.{$field_name}_url,
                   IFNULL({$field_table}.{$field_name}_title, ''),
                   IFNULL({$field_table}.{$field_name}_override, '')

--- a/src/RWAPIIndexer/Resources/Topic.php
+++ b/src/RWAPIIndexer/Resources/Topic.php
@@ -104,6 +104,7 @@ class Topic extends Resource {
       // Tags.
       ->addTaxonomy('theme')
       ->addTaxonomy('disaster_type')
+      ->addString('disaster_type.code', FALSE)
       // Images.
       ->addImage('icon')
       // Flags.

--- a/src/RWAPIIndexer/Resources/Topic.php
+++ b/src/RWAPIIndexer/Resources/Topic.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace RWAPIIndexer\Resources;
+
+use RWAPIIndexer\Resource;
+use RWAPIIndexer\Mapping;
+
+/**
+ * Topic resource handler.
+ */
+class Topic extends Resource {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $queryOptions = [
+    'fields' => [
+      'title' => 'title',
+      'date_created' => 'created',
+      'date_changed' => 'changed',
+      'status' => 'moderation_status',
+    ],
+    'field_joins' => [
+      'body' => [
+        'introduction' => 'value',
+      ],
+      'field_overview' => [
+        'overview' => 'value',
+      ],
+      'field_resources' => [
+        'resources' => 'value',
+      ],
+      'field_disasters_search' => [
+        'disasters_search' => 'river_search',
+      ],
+      'field_jobs_search' => [
+        'jobs_search' => 'river_search',
+      ],
+      'field_reports_search' => [
+        'reports_search' => 'river_search',
+      ],
+      'field_training_search' => [
+        'training_search' => 'river_search',
+      ],
+      'field_sections' => [
+        'sections' => 'river_search',
+      ],
+      'field_icon' => [
+        'icon' => 'image_reference',
+      ],
+      'field_featured' => [
+        'featured' => 'value',
+      ],
+    ],
+    'references' => [
+      'field_theme' => 'theme',
+      'field_disaster_type' => 'disaster_type',
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $processingOptions = [
+    'conversion' => [
+      'introduction' => ['links', 'html_iframe'],
+      'overview' => ['links', 'html_iframe'],
+      'resources' => ['links', 'html'],
+      'date_created' => ['time'],
+      'date_changed' => ['time'],
+      'featured' => ['bool'],
+    ],
+    'references' => [
+      'theme' => [
+        'theme' => ['id', 'name'],
+      ],
+      'disaster_type' => [
+        'disaster_type' => ['id', 'name', 'code'],
+      ],
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMapping() {
+    $mapping = new Mapping();
+    $mapping->addInteger('id')
+      ->addString('url', FALSE)
+      ->addString('url_alias', FALSE)
+      ->addStatus()
+      ->addString('title', TRUE, TRUE)
+      // Body.
+      ->addString('introduction')
+      ->addString('introduction-html', NULL)
+      ->addString('overview')
+      ->addString('overview-html', NULL)
+      ->addString('resources')
+      ->addString('resources-html', NULL)
+      // Dates.
+      ->addDates('date', ['created', 'changed'])
+      // Rivers.
+      ->addRiverSearch('rivers')
+      // Tags.
+      ->addTaxonomy('theme')
+      ->addTaxonomy('disaster_type')
+      // Images.
+      ->addImage('icon')
+      // Flags.
+      ->addBoolean('featured');
+
+    return $mapping->export();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem(&$item) {
+    // Handle dates.
+    $item['date'] = [
+      'created' => $item['date_created'],
+      'changed' => $item['date_changed'],
+    ];
+    unset($item['date_created']);
+    unset($item['date_changed']);
+
+    // Handle icon.
+    if ($this->processor->processImage($item['icon'], TRUE, FALSE, FALSE) !== TRUE) {
+      unset($item['icon']);
+    }
+
+    // Handle rivers.
+    $rivers = [
+      'disasters' => [
+        'id' => 'disasters',
+        'title' => 'Disasters',
+      ],
+      'jobs' => [
+        'id' => 'jobs',
+        'title' => 'Jobs',
+      ],
+      'reports' => [
+        'id' => 'reports',
+        'title' => 'Latest Updates',
+      ],
+      'training' => [
+        'id' => 'training',
+        'title' => 'Training',
+      ],
+    ];
+
+    foreach ($rivers as $id => $info) {
+      if (!empty($item[$id . '_search']) && $this->processor->processRiverSearch($item[$id . '_search'], TRUE)) {
+        $rivers[$id] += $item[$id . '_search'];
+      }
+      else {
+        unset($rivers[$id]);
+      }
+      unset($item[$id . '_search']);
+    }
+
+    if (!empty($item['sections']) && $this->processor->processRiverSearch($item['sections'])) {
+      foreach ($item['sections'] as $index => $section) {
+        $rivers[] = $section + [
+          'id' => 'section-' . ($index + 1),
+        ];
+      }
+    }
+    unset($item['sections']);
+
+    if (!empty($rivers)) {
+      $item['rivers'] = array_values($rivers);
+    }
+  }
+
+}


### PR DESCRIPTION
Refs: RW-598, RW-655

This adds the indexing of the topics and ensures the order of the attachments, images and topic river search links are preserved.

Related PR to add the topics resource to the API: https://github.com/UN-OCHA/rwint-api/pull/100

Note: follow-up ticket to decide what to do with the disaster map tokens: https://humanitarian.atlassian.net/browse/RW-653

### Tests

First: replace `vendor/reliefweb/api-indexer` in rwint9 repo with the code from this branch

**Topics**

1. Run `drush rapi-i --tag=test --alias topic`
2. Check that the data is in ES (`curl http://elasticsearch:9200/_cat/indices|grep topics` on the RW9 container)

**Attachment order**

1. Create a report with multiple attachments, add descriptions to help identify them (ex:  `File 1`, `File 2` etc.)
2. Get the local API record for this report and check that the files are in order
3. Change the order of the files on the RW9 local site
4. Get the local API record for this report and check that the files are in the new order