### PR TITLE
[RW-653] Convert disaster map token to iframe

### DIFF
--- a/src/RWAPIIndexer/Manager.php
+++ b/src/RWAPIIndexer/Manager.php
@@ -77,7 +77,7 @@ class Manager {
     );
 
     // Create a new field processor object to prepare items before indexing.
-    $this->processor = new Processor($this->options->get('website'), $this->references);
+    $this->processor = new Processor($this->options->get('website'), $this->connection, $this->references);
   }
 
   /**

--- a/src/RWAPIIndexer/Resources/Country.php
+++ b/src/RWAPIIndexer/Resources/Country.php
@@ -132,7 +132,7 @@ class Country extends Resource {
       unset($item['description']);
     }
     else {
-      $this->processor->processProfile($this->connection, $item, $this->profileSections);
+      $this->processor->processProfile($item, $this->profileSections);
     }
     unset($item['show_profile']);
 

--- a/src/RWAPIIndexer/Resources/Disaster.php
+++ b/src/RWAPIIndexer/Resources/Disaster.php
@@ -173,7 +173,7 @@ class Disaster extends Resource {
       unset($item['description']);
     }
     else {
-      $this->processor->processProfile($this->connection, $item, $this->profileSections);
+      $this->processor->processProfile($item, $this->profileSections);
     }
     unset($item['show_profile']);
   }

--- a/src/RWAPIIndexer/Resources/Topic.php
+++ b/src/RWAPIIndexer/Resources/Topic.php
@@ -63,8 +63,8 @@ class Topic extends Resource {
    */
   protected $processingOptions = [
     'conversion' => [
-      'introduction' => ['links', 'html_iframe'],
-      'overview' => ['links', 'html_iframe'],
+      'introduction' => ['links', 'html'],
+      'overview' => ['links', 'html_iframe_disaster_map'],
       'resources' => ['links', 'html'],
       'date_created' => ['time'],
       'date_changed' => ['time'],


### PR DESCRIPTION
Refs: RW-653

This converts the `[disaster-map:XX]` tokens to an iframe to the disaster map endpoint added in https://github.com/UN-OCHA/rwint9-site/pull/486.

**Note:** We are only converting the token in the `overview-html` not in the `overview` which contains the raw markdown so it can be used on the RW9 site without reverse conversion.