### PR TITLE
[RW-756] Index redirects

### DIFF
--- a/src/RWAPIIndexer/Processor.php
+++ b/src/RWAPIIndexer/Processor.php
@@ -681,11 +681,16 @@ class Processor {
    *   Item to which add the URL field.
    * @param string $alias
    *   URL alias for the entity.
+   * @param array $redirects
+   *   List of old URLs that redirect to this entity.
    */
-  public function processEntityUrl($entity_type, array &$item, $alias) {
+  public function processEntityUrl($entity_type, array &$item, $alias, array $redirects = []) {
     $item['url'] = $this->website . '/' . str_replace('_', '/', $entity_type) . '/' . $item['id'];
     if (!empty($alias)) {
       $item['url_alias'] = $this->website . '/' . ltrim($this->encodePath($alias), '/');
+    }
+    foreach ($redirects as $url) {
+      $item['redirects'][] = $this->website . '/' . ltrim($this->encodePath($url), '/');
     }
   }
 

--- a/src/RWAPIIndexer/Resource.php
+++ b/src/RWAPIIndexer/Resource.php
@@ -81,6 +81,13 @@ abstract class Resource {
   protected $options = NULL;
 
   /**
+   * Database query object to get items to index.
+   *
+   * @var \RWAPIIndexer\Database\Query
+   */
+  protected $query;
+
+  /**
    * Construct the resource handler.
    *
    * @param string $bundle

--- a/src/RWAPIIndexer/Resources/Blog.php
+++ b/src/RWAPIIndexer/Resources/Blog.php
@@ -63,6 +63,7 @@ class Blog extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       ->addString('author', TRUE, TRUE)

--- a/src/RWAPIIndexer/Resources/Book.php
+++ b/src/RWAPIIndexer/Resources/Book.php
@@ -46,6 +46,7 @@ class Book extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       // Body.

--- a/src/RWAPIIndexer/Resources/Country.php
+++ b/src/RWAPIIndexer/Resources/Country.php
@@ -87,6 +87,7 @@ class Country extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addBoolean('current')
       ->addBoolean('featured')

--- a/src/RWAPIIndexer/Resources/Disaster.php
+++ b/src/RWAPIIndexer/Resources/Disaster.php
@@ -109,6 +109,7 @@ class Disaster extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addDates('date', ['created', 'changed', 'event'])
       ->addBoolean('featured')

--- a/src/RWAPIIndexer/Resources/Job.php
+++ b/src/RWAPIIndexer/Resources/Job.php
@@ -97,6 +97,7 @@ class Job extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       // Body.

--- a/src/RWAPIIndexer/Resources/Report.php
+++ b/src/RWAPIIndexer/Resources/Report.php
@@ -131,6 +131,7 @@ class Report extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       ->addString('origin', FALSE)

--- a/src/RWAPIIndexer/Resources/Source.php
+++ b/src/RWAPIIndexer/Resources/Source.php
@@ -90,6 +90,7 @@ class Source extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('homepage', FALSE)
       ->addString('content_type', FALSE)

--- a/src/RWAPIIndexer/Resources/Topic.php
+++ b/src/RWAPIIndexer/Resources/Topic.php
@@ -88,6 +88,7 @@ class Topic extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       // Body.

--- a/src/RWAPIIndexer/Resources/Training.php
+++ b/src/RWAPIIndexer/Resources/Training.php
@@ -116,6 +116,7 @@ class Training extends Resource {
     $mapping->addInteger('id')
       ->addString('url', FALSE)
       ->addString('url_alias', FALSE)
+      ->addString('redirects', FALSE)
       ->addStatus()
       ->addString('title', TRUE, TRUE)
       // Body.


### PR DESCRIPTION
Refs: RW-756

This adds in the indexing of the URL redirects for content entities to ease looking up documents by URL alias.

This indexes the entries from the `redirect` Drupal table to ease lookups (see https://github.com/UN-OCHA/rwint-api/pull/132).